### PR TITLE
Fix for mounting vhd with efi/fat32 partition

### DIFF
--- a/Add-GPUPartitiontoExistingVM.psm1
+++ b/Add-GPUPartitiontoExistingVM.psm1
@@ -55,7 +55,7 @@
     }
 
     "Mounting Drive..."
-    $DriveLetter = (Mount-VHD -Path $DiskPath -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+    $DriveLetter = (Mount-VHD -Path $DiskPath -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter  -and $_.FileSystemType -eq "NTFS"} | ForEach-Object DriveLetter)
 
     if (-Not $DriveLetter) {
         'Drive is not mounted'

--- a/Update-VMGpuPartitionDriver.psm1
+++ b/Update-VMGpuPartitionDriver.psm1
@@ -31,7 +31,7 @@
     }
 
     "Mounting Drive..."
-    $DriveLetter = (Mount-VHD -Path $DiskPath -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+    $DriveLetter = (Mount-VHD -Path $DiskPath -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter  -and $_.FileSystemType -eq "NTFS"} | ForEach-Object DriveLetter)
 
     if (-Not $DriveLetter) {
         'Drive is not mounted'


### PR DESCRIPTION
Quick hack in case a vhd has several partitions and the drive letter will be an array instead of a single entry. 
Typically windows partition scheme: 
1. System (efi)
2. Reserved
3. Main (NTFS)

